### PR TITLE
Fix installation text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This installer targets the **USB version** of the board, if you have the SPI ver
 ## Setup based on Raspbian image
 
 - Download [Raspbian Jessie Lite](https://www.raspberrypi.org/downloads/)
-- Follow the [installation instruction](https://www.raspberrypi.org/documentation/installation/installing-images/README.md) to create the SD card
+- Follow the [installation instructions](https://www.raspberrypi.org/documentation/installation/installing-images/README.md) to create the SD card
 - Start your RPi connected to Ethernet
 - Plug the iC880a (**WARNING**: first power plug to the wall socket, then to the gateway DC jack, and ONLY THEN USB to RPi!)
 - From a computer in the same LAN, `ssh` into the RPi using the default hostname:


### PR DESCRIPTION
## Summary
- fix plural usage of "installation instructions" in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f68d926f48328827f8a45e80c2fd2