### PR TITLE
Add ESP32 SGP41 OLED demo

### DIFF
--- a/esp32-sgp41-oled/README.md
+++ b/esp32-sgp41-oled/README.md
@@ -23,6 +23,9 @@ protection.
 | GPIO21 (SDA) | SDA   | SDA  |
 | GPIO22 (SCL) | SCL   | SCL  |
 
+The example defines these pins as `SDA_PIN` and `SCL_PIN` in `src/main.cpp`. If
+your board uses different I²C pins, adjust the constants accordingly.
+
 Connect the battery to the TP4056 module, then to the MTS-103 switch, and finally
 feed the ESP32's `VBAT` or `5V` input (according to your module). The charger
 module prevents overcharging of the cell.

--- a/esp32-sgp41-oled/README.md
+++ b/esp32-sgp41-oled/README.md
@@ -1,45 +1,35 @@
-# ESP32-S3 SGP41 OLED Demo
+# Demo ESP32-S3 SGP41 OLED
 
-This example project shows how to read air quality data from the Sensirion SGP41 sensor
-and display the raw values on a 0.96" OLED (SSD1306 128x64 dots) using C++ on the
-Arduino framework. Hardware power is controlled with a lever switch and a
-rechargeable 18650 battery using a TP4056 charging module with overcharge
-protection.
+Questo esempio mostra come leggere i valori grezzi di VOC e NOx dal sensore Sensirion SGP41 e visualizzarli su un display OLED SSD1306 da 0,96" con il framework Arduino. L'alimentazione avviene tramite batteria 18650 ricaricata da un modulo TP4056 e controllata da un interruttore MTS-103.
 
 ## Hardware
 
-- **Microcontroller**: ESP32-S3 module
-- **Gas sensor**: Sensirion SGP41 (I²C address `0x59`)
-- **Display**: 0.96" OLED, SSD1306 controller, 128x64 pixels (I²C)
-- **Power**: 18650 Li-Ion battery, TP4056 charger with protection, MTS-103 toggle
-  switch to cut power
+- **Microcontrollore**: modulo ESP32-S3
+- **Sensore gas**: Sensirion SGP41 (indirizzo I²C `0x59`)
+- **Display**: OLED 0,96" SSD1306, 128x64 pixel
+- **Alimentazione**: batteria 18650, caricatore TP4056 con protezione e interruttore a levetta MTS-103
 
-### Wiring
+### Collegamenti
 
-| ESP32-S3 Pin | SGP41 | OLED |
-|--------------|-------|------|
-| 3V3          | VCC   | VCC  |
-| GND          | GND   | GND  |
-| GPIO21 (SDA) | SDA   | SDA  |
-| GPIO22 (SCL) | SCL   | SCL  |
+| Pin ESP32-S3  | SGP41 | OLED |
+|---------------|-------|------|
+| 3V3           | VCC   | VCC  |
+| GND           | GND   | GND  |
+| GPIO21 (SDA)  | SDA   | SDA  |
+| GPIO22 (SCL)  | SCL   | SCL  |
 
-The example defines these pins as `SDA_PIN` and `SCL_PIN` in `src/main.cpp`. If
-your board uses different I²C pins, adjust the constants accordingly.
+Nel codice questi pin sono definiti come `SDA_PIN` e `SCL_PIN`. Se la tua scheda usa pin differenti, modifica queste costanti in `src/main.cpp`.
 
-Connect the battery to the TP4056 module, then to the MTS-103 switch, and finally
-feed the ESP32's `VBAT` or `5V` input (according to your module). The charger
-module prevents overcharging of the cell.
+Collega la batteria al modulo TP4056, quindi all'interruttore MTS-103 e infine al pin di alimentazione dell'ESP32 ("VBAT" o "5V" a seconda del modulo). Il TP4056 protegge la cella da sovraccarica.
 
-## Build
+## Compilazione
 
-Use PlatformIO or the Arduino IDE with ESP32 core 2.0 or later. Required
-libraries:
+Usa PlatformIO o l'Arduino IDE (core ESP32 >= 2.0). Le librerie necessarie sono:
 
 - `Adafruit SSD1306`
 - `Adafruit GFX`
 - `Sensirion I2C SGP41`
 
-## Usage
+## Utilizzo
 
-Upload the sketch in `src/main.cpp` to your board. The display shows the raw VOC
-and NOx signals reported by the SGP41 every second.
+Carica lo sketch in `src/main.cpp` sulla tua scheda. Il display mostrerà ogni secondo i valori grezzi di VOC e NOx letti dal sensore.

--- a/esp32-sgp41-oled/README.md
+++ b/esp32-sgp41-oled/README.md
@@ -1,0 +1,42 @@
+# ESP32-S3 SGP41 OLED Demo
+
+This example project shows how to read air quality data from the Sensirion SGP41 sensor
+and display the raw values on a 0.96" OLED (SSD1306 128x64 dots) using C++ on the
+Arduino framework. Hardware power is controlled with a lever switch and a
+rechargeable 18650 battery using a TP4056 charging module with overcharge
+protection.
+
+## Hardware
+
+- **Microcontroller**: ESP32-S3 module
+- **Gas sensor**: Sensirion SGP41 (I²C address `0x59`)
+- **Display**: 0.96" OLED, SSD1306 controller, 128x64 pixels (I²C)
+- **Power**: 18650 Li-Ion battery, TP4056 charger with protection, MTS-103 toggle
+  switch to cut power
+
+### Wiring
+
+| ESP32-S3 Pin | SGP41 | OLED |
+|--------------|-------|------|
+| 3V3          | VCC   | VCC  |
+| GND          | GND   | GND  |
+| GPIO21 (SDA) | SDA   | SDA  |
+| GPIO22 (SCL) | SCL   | SCL  |
+
+Connect the battery to the TP4056 module, then to the MTS-103 switch, and finally
+feed the ESP32's `VBAT` or `5V` input (according to your module). The charger
+module prevents overcharging of the cell.
+
+## Build
+
+Use PlatformIO or the Arduino IDE with ESP32 core 2.0 or later. Required
+libraries:
+
+- `Adafruit SSD1306`
+- `Adafruit GFX`
+- `Sensirion I2C SGP41`
+
+## Usage
+
+Upload the sketch in `src/main.cpp` to your board. The display shows the raw VOC
+and NOx signals reported by the SGP41 every second.

--- a/esp32-sgp41-oled/platformio.ini
+++ b/esp32-sgp41-oled/platformio.ini
@@ -1,0 +1,9 @@
+[env:esp32-s3]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    adafruit/Adafruit SSD1306 @ ^2.5.7
+    adafruit/Adafruit GFX Library @ ^1.11.5
+    Sensirion/Sensirion I2C SGP41 @ ^2.0.0

--- a/esp32-sgp41-oled/src/main.cpp
+++ b/esp32-sgp41-oled/src/main.cpp
@@ -7,12 +7,17 @@
 #define SCREEN_HEIGHT 64
 #define OLED_RESET -1
 
+// I2C pins used for both the SGP41 sensor and the SSD1306 display
+#define SDA_PIN 21
+#define SCL_PIN 22
+
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 SensirionI2CSgp41 sgp41;
 
 void setup() {
     Serial.begin(115200);
-    Wire.begin();
+    // Initialize I2C bus with explicit pins
+    Wire.begin(SDA_PIN, SCL_PIN);
 
     if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
         Serial.println(F("OLED init failed"));

--- a/esp32-sgp41-oled/src/main.cpp
+++ b/esp32-sgp41-oled/src/main.cpp
@@ -1,0 +1,50 @@
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+#include <SensirionI2CSgp41.h>
+
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 64
+#define OLED_RESET -1
+
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
+SensirionI2CSgp41 sgp41;
+
+void setup() {
+    Serial.begin(115200);
+    Wire.begin();
+
+    if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
+        Serial.println(F("OLED init failed"));
+        while (true)
+            ;
+    }
+
+    display.clearDisplay();
+    display.setTextSize(1);
+    display.setTextColor(SSD1306_WHITE);
+    display.setCursor(0, 0);
+    display.println(F("SGP41 Demo"));
+    display.display();
+
+    sgp41.begin(Wire);
+    // Conditioning, uses default values for humidity and temperature (0)
+    sgp41.executeConditioning(0, 0);
+}
+
+void loop() {
+    uint16_t vocRaw = 0;
+    uint16_t noxRaw = 0;
+    if (sgp41.measureRawSignal(vocRaw, noxRaw) == 0) {
+        display.clearDisplay();
+        display.setCursor(0, 0);
+        display.print(F("VOC: "));
+        display.println(vocRaw);
+        display.print(F("NOx: "));
+        display.println(noxRaw);
+        display.display();
+    } else {
+        Serial.println(F("SGP41 read failed"));
+    }
+    delay(1000);
+}

--- a/esp32-sgp41-oled/src/main.cpp
+++ b/esp32-sgp41-oled/src/main.cpp
@@ -3,11 +3,12 @@
 #include <Adafruit_SSD1306.h>
 #include <SensirionI2CSgp41.h>
 
+// Dimensioni dello schermo OLED
 #define SCREEN_WIDTH 128
 #define SCREEN_HEIGHT 64
 #define OLED_RESET -1
 
-// I2C pins used for both the SGP41 sensor and the SSD1306 display
+// Piedini I2C condivisi da SGP41 e display SSD1306
 #define SDA_PIN 21
 #define SCL_PIN 22
 
@@ -16,30 +17,32 @@ SensirionI2CSgp41 sgp41;
 
 void setup() {
     Serial.begin(115200);
-    // Initialize I2C bus with explicit pins
+    // Inizializzo il bus I2C con i pin definiti sopra
     Wire.begin(SDA_PIN, SCL_PIN);
 
     if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
-        Serial.println(F("OLED init failed"));
-        while (true)
-            ;
+        Serial.println(F("Errore inizializzazione OLED"));
+        while (true) {
+            // Resto bloccato finché il display non viene inizializzato correttamente
+        }
     }
 
     display.clearDisplay();
     display.setTextSize(1);
     display.setTextColor(SSD1306_WHITE);
     display.setCursor(0, 0);
-    display.println(F("SGP41 Demo"));
+    display.println(F("Demo SGP41"));
     display.display();
 
     sgp41.begin(Wire);
-    // Conditioning, uses default values for humidity and temperature (0)
+    // Avvio la fase di condizionamento con umidità e temperatura predefinite (0)
     sgp41.executeConditioning(0, 0);
 }
 
 void loop() {
     uint16_t vocRaw = 0;
     uint16_t noxRaw = 0;
+
     if (sgp41.measureRawSignal(vocRaw, noxRaw) == 0) {
         display.clearDisplay();
         display.setCursor(0, 0);
@@ -49,7 +52,8 @@ void loop() {
         display.println(noxRaw);
         display.display();
     } else {
-        Serial.println(F("SGP41 read failed"));
+        Serial.println(F("Errore lettura SGP41"));
     }
+
     delay(1000);
 }


### PR DESCRIPTION
## Summary
- add example project for ESP32-S3 with SGP41 sensor and OLED display
- provide PlatformIO configuration and hardware notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f67f0dca08328a2aeb12f9a20797f